### PR TITLE
add pyFPGA content

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -33,6 +33,7 @@ params:
     "Tools": ""
     "Tools:Bitgen": ""
     "Tools:Grammars": ""
+    "Tools:Managers": ""
     "Tools:Package Managers": ""
     "Tools:Parsers": ""
     "Tools:PnRs": ""

--- a/content/items/pyFPGA.md
+++ b/content/items/pyFPGA.md
@@ -6,34 +6,39 @@ authors:
 links:
   gl: rodrigomelo9/pyfpga
   docs: https://rodrigomelo9.gitlab.io/pyfpga
-categories:
-  - TBD
-tags:
-  - vivado
-  - ise
-  - quartus
-  - libero
-  - ghdl
-  - yosys
-  - nextpnr
-  - icestorm
-  - trellis
-  - vhdl
-  - verilog
-  - python
-  - tcl
+categories: [
+  "Tools",
+  "Tools:Managers"
+]
+tags: [
+  "vivado",
+  "ise",
+  "quartus",
+  "libero",
+  "ghdl",
+  "yosys",
+  "nextpnr",
+  "icestorm",
+  "trellis",
+  "vhdl",
+  "verilog",
+  "python",
+  "tcl"
+]
 active:
   from: 2019
-licenses: "GNU GPLv3"
+licenses: [
+  "GPL-3.0-or-later"
+]
 talk: 58
 ---
 
 PyFPGA is a Python Class for vendor-independent FPGA development.
-It allows using a single project file and programmatically executing
-synthesis, implementation, generation of bitstream and/or
-transference to supported boards.
+It allows using a single project file and programmatically executing synthesis, implementation, generation of bitstream and/or transference to supported boards.
 
 * The workflow is command-line centric.
 * It's friendly with Version Control Systems and Continuous Integration (CI).
 * Allows reproducibility and repeatability.
 * Consumes fewer system resources than GUI based workflows.
+
+Also, some command-line helpers are provided, for quick tests or small projects.

--- a/content/items/pyFPGA.md
+++ b/content/items/pyFPGA.md
@@ -6,10 +6,34 @@ authors:
 links:
   gl: rodrigomelo9/pyfpga
   docs: https://rodrigomelo9.gitlab.io/pyfpga
-tags: []
+categories:
+  - TBD
+tags:
+  - vivado
+  - ise
+  - quartus
+  - libero
+  - ghdl
+  - yosys
+  - nextpnr
+  - icestorm
+  - trellis
+  - vhdl
+  - verilog
+  - python
+  - tcl
+active:
+  from: 2019
+licenses: "GNU GPLv3"
 talk: 58
 ---
 
-This is a long description...
-<!--more-->
-... about pyFPGA.
+PyFPGA is a Python Class for vendor-independent FPGA development.
+It allows using a single project file and programmatically executing
+synthesis, implementation, generation of bitstream and/or
+transference to supported boards.
+
+* The workflow is command-line centric.
+* It's friendly with Version Control Systems and Continuous Integration (CI).
+* Allows reproducibility and repeatability.
+* Consumes fewer system resources than GUI based workflows.

--- a/template.md
+++ b/template.md
@@ -1,5 +1,6 @@
 # <SOMETHING> means "change me"
 # FIELD? means "optional"
+# Use SPDX identifiers for licenses (https://spdx.org/licenses/)
 
 ---
 title: "<TITLE>"


### PR DESCRIPTION
Hi. I added content to pyFPGA but I have a few doubts:
* Category? `Tools`, of course, but something more? The most similar is `Tools:Package Managers` but is not exactly. `Tools managers`? `Project Managers`? (the same category will apply other tools such as hdlmake, edalize, tsfpga, etc).
*  I filled license with "GNU GPLv3". Maybe we need a list of licenses and how to be specified? Others tools have not this field. Some of them, have the license as extra info, as long description (ex: Vunit -> *License: [Mozilla Public License, v. 2.0.](https://github.com/VUnit/vunit/blob/master/LICENSE.txt) baring OSVVM components.*).
* What about tags? Do you see that list ok? Is huge?

Let me know how can I help to define these things (add a category, a licenses list, etc). 