### PR TITLE
add multi-links support and logos for bitbucket, git, scm and sourcef…

### DIFF
--- a/layouts/partials/icons.html
+++ b/layouts/partials/icons.html
@@ -24,16 +24,17 @@
     {{ $icon = "web" }}
   {{ end }}
 
-  {{ if not (isset $value -1) }} <!-- if not an array -->
-    {{ $value = slice $value }} <!-- convert to an array -->
-  {{ end }}
-
-  {{ range $value }} <!-- always used as array-->
-    <a class="level-item" href="{{ $prefix }}{{ .}}" rel="noopener" target="_blank">
+  {{ if not (eq $value nil) }} <!-- if field not empty -->
+    {{ if not (isset $value -1) }} <!-- if not an array -->
+      {{ $value = slice $value }} <!-- convert to an array -->
+    {{ end }}
+    {{ range $value }} <!-- always used as array-->
+    <a class="level-item" href="{{ $prefix }}{{ . }}" rel="noopener" target="_blank">
       <span class="icon">
-        <img alt="" src='{{ (resources.Get (printf "icons/svg/%s.svg" $icon)).Permalink }}'>
+        <img title="{{ $key }}: {{ . }}" src='{{ (resources.Get (printf "icons/svg/%s.svg" $icon)).Permalink }}'>
       </span>
     </a>
+    {{ end }}
   {{ end }}
 
 {{ end }}

--- a/layouts/partials/icons.html
+++ b/layouts/partials/icons.html
@@ -1,30 +1,39 @@
-{{ with .Params.Links }}
-  {{ with .Web }}
-    <a class="level-item" href="{{ . }}" rel="noopener" target="_blank">
+{{ range $key, $value := .Params.Links }}
+
+  {{ $prefix := "" }}
+  {{ $icon := "" }}
+  {{ if eq $key "bb" }}
+    {{ $prefix = "https://bitbucket.org/" }}
+    {{ $icon = "bitbucket" }}
+  {{ else if eq $key "gh" }}
+    {{ $prefix = "https://github.com/" }}
+    {{ $icon = "github" }}
+  {{ else if eq $key "gl" }}
+    {{ $prefix = "https://gitlab.com/" }}
+    {{ $icon = "gitlab" }}
+  {{ else if eq $key "sf" }}
+    {{ $prefix = "https://sourceforge.net/projects/" }}
+    {{ $icon = "fire" }}
+  {{ else if eq $key "docs" }}
+    {{ $icon = "book-open-page-variant" }}
+  {{ else if eq $key "git" }}
+    {{ $icon = "git" }}
+  {{ else if eq $key "scm" }}
+    {{ $icon = "source-repository" }}
+  {{ else }}
+    {{ $icon = "web" }}
+  {{ end }}
+
+  {{ if not (isset $value -1) }} <!-- if not an array -->
+    {{ $value = slice $value }} <!-- convert to an array -->
+  {{ end }}
+
+  {{ range $value }} <!-- always used as array-->
+    <a class="level-item" href="{{ $prefix }}{{ .}}" rel="noopener" target="_blank">
       <span class="icon">
-        <img alt="" src='{{ (resources.Get (printf "icons/svg/%s.svg" "web")).Permalink }}'>
+        <img alt="" src='{{ (resources.Get (printf "icons/svg/%s.svg" $icon)).Permalink }}'>
       </span>
     </a>
   {{ end }}
-  {{ with .Docs }}
-    <a class="level-item" href="{{ . }}" rel="noopener" target="_blank">
-      <span class="icon">
-        <img alt="" src='{{ (resources.Get (printf "icons/svg/%s.svg" "book-open-page-variant")).Permalink }}'>
-      </span>
-    </a>
-  {{ end }}
-  {{ with .Gh }}
-    <a class="level-item" href="https://github.com/{{ . }}" rel="noopener" target="_blank">
-      <span class="icon">
-        <img alt="" src='{{ (resources.Get (printf "icons/svg/%s.svg" "github")).Permalink }}'>
-      </span>
-    </a>
-  {{ end }}
-  {{ with .Gl }}
-    <a class="level-item" href="https://gitlab.com/{{ . }}" rel="noopener" target="_blank">
-      <span class="icon">
-        <img alt="" src='{{ (resources.Get (printf "icons/svg/%s.svg" "gitlab")).Permalink }}'>
-      </span>
-    </a>
-  {{ end }}
+
 {{ end }}


### PR DESCRIPTION
This PR adds support for multiple links per group (`gh`, `gl`, `docs`, `web`). It also adds support for `bb`, `sf`, `git` and `scm` (with special icons for them).

Something like that:
```yaml
links:
  gh:
  - aaa/bbb
  - ccc/ddd
  gl: eee/fff
  docs: https://www.ggg.com
  web:
  - https://www.hhh.com
  - https://www.iii.com
  scm: https://www.jjj.com
  bb: kkk/lll
  sf: gtkwave
  git:
  - https://git-repo1.com
  - https://git_repo2.com
```

Produces:

![Image](https://user-images.githubusercontent.com/3329860/108774679-b8931080-753e-11eb-9c2c-e8b06d36f2cf.png)

Closes #172 