### PR TITLE
Update rggen.md

### DIFF
--- a/content/items/rggen.md
+++ b/content/items/rggen.md
@@ -28,6 +28,7 @@ RgGen has following features:
 
 * Generate following source files for CSR automatically from register map specifications
     * SystemVerilog/Verilog RTL
+    * [Veryl](https://veryl-lang.org) RTL
     * VHDL RTL
     * UVM register model (RAL)
     * Markdown documents


### PR DESCRIPTION
Today I release RgGen v0.33.4.
Veryl RTL generation is officially supported from this release.

This PR is to add this update.

About Veryl:

Veryl is a mordan hardware description langurage specialized for RTL design designed by my colleague @dalance.
Please visit the official side for more details about Veryl lang.
https://veryl-lang.org