### PR TITLE
Fix Axion-HDL category: Tools -> Tools:CSR Automation

### DIFF
--- a/content/items/axion-hdl.md
+++ b/content/items/axion-hdl.md
@@ -22,7 +22,7 @@ tags:
   - RTL
   - Python
 categories:
-  - Tools
+  - "Tools:CSR Automation"
 licenses:
   - MIT
 active:


### PR DESCRIPTION
The initial entry for Axion-HDL was merged under the generic `Tools` category. Since Axion-HDL is a CSR automation tool (similar to PeakRDL which is already listed under `Tools:CSR Automation`), this PR moves it to the correct subcategory.

No other changes.