### PR TITLE
Add Synth Explorer

### DIFF
--- a/content/items/synth-explorer.md
+++ b/content/items/synth-explorer.md
@@ -1,0 +1,26 @@
+---
+title: "Synth Explorer"
+description: "Browser-based Compiler Explorer for RTL: synthesize with Yosys and GHDL in WebAssembly and inspect the netlist client-side"
+authors: []
+links:
+  web: https://www.synthexplorer.dev
+  gh: cachanova/synth-explorer
+categories: [
+  "Tools",
+  "Tools:Synthesizers",
+]
+tags: [
+  "synthesis",
+  "verilog",
+  "vhdl",
+  "netlist",
+]
+licenses: [
+  "Apache-2.0",
+]
+talk: 249
+---
+
+A browser-based "Compiler Explorer" for RTL. Yosys and GHDL are compiled to WebAssembly and run entirely client-side, so Verilog, SystemVerilog and VHDL-2008 sources are synthesized locally and never leave the browser.
+<!--more-->
+The synthesized netlist can be explored interactively by path, endpoint, fanin, fanout, or source location, making it useful for teaching synthesis, debugging elaboration, and quickly inspecting how HDL maps to gates.


### PR DESCRIPTION
Adds Synth Explorer, a browser-based Compiler Explorer for RTL. Yosys and GHDL are compiled to WebAssembly and run entirely client-side, so Verilog/SystemVerilog/VHDL-2008 is synthesized locally and the netlist can be explored interactively.

- Web: https://www.synthexplorer.dev
- Source: https://github.com/cachanova/synth-explorer (Apache-2.0)

Opened per the discussion in #249. Categorized under `Tools:Synthesizers` using the existing taxonomy. If you'd prefer a dedicated `Tools:Explorer` (or `Viewer`) category, I'm happy to add it to `config.yml` in this PR — just say the word.